### PR TITLE
fix: close modal on background click and darken rendered markdown

### DIFF
--- a/frontend/src/routes/components/HelpModal.svelte
+++ b/frontend/src/routes/components/HelpModal.svelte
@@ -9,7 +9,7 @@
 
 <!-- Help Modal -->
 <dialog open={displayHelpModal.state} class="help-modal" id="help-modal">
-	<div class="help-modal--back" id="help-modal--back"></div>
+	<div on:click={closeHelp} class="help-modal--back" id="help-modal--back"></div>
 
 	<div class="help-modal--container">
 		<div class="help-modal--header">

--- a/frontend/src/routes/components/renderer/Telegram.svelte
+++ b/frontend/src/routes/components/renderer/Telegram.svelte
@@ -75,9 +75,6 @@
 	<div class="chat-background">
 		<enhanced:img src={backgroundImage} alt="telegram-background" />
 	</div>
-	<div class="char-count" style={count_color_indicator}>
-		Character number: <code>{htmlContent.length}/{TELEGRAM_CHAR_LIMIT_PER_MESSAGE}</code>
-	</div>
 	<div class="telegram-bubble-content-wrapper">
 		<div class="telegram-bubble-content">
 			<div class="telegram-message-wrapper">
@@ -88,6 +85,9 @@
 				</div>
 			</div>
 		</div>
+	</div>
+	<div class="char-count" style={count_color_indicator}>
+		Character number: <code>{htmlContent.length}/{TELEGRAM_CHAR_LIMIT_PER_MESSAGE}</code>
 	</div>
 </div>
 
@@ -100,7 +100,6 @@
 	.char-count {
 		position: absolute;
 		margin: 5px;
-		z-index: 4;
 		top: 0.5rem;
 		right: 0.5rem;
 		background-color: rgba(var(--indic-color), 0.5); /* teal-600 */
@@ -123,12 +122,10 @@
 		width: 100%;
 		object-fit: cover;
 		pointer-events: none; /* ensures it doesn't block content */
-		z-index: 0;
 	}
 
 	.telegram-bubble-content-wrapper {
 		padding: 30px;
-		z-index: 1;
 		height: 100%;
 		overflow-y: auto;
 	}

--- a/frontend/src/routes/components/renderer/css/telegram-new-renderer.css
+++ b/frontend/src/routes/components/renderer/css/telegram-new-renderer.css
@@ -39,7 +39,6 @@
   position: relative;
   scrollbar-color: rgba(0, 0, 0, 0) rgba(0, 0, 0, 0);
   user-select: text;
-  z-index: 2
 }
 
 .telegram-message-wrapper {
@@ -109,7 +108,6 @@
   flex: 0 0 auto;
   width: .1875rem;
   background: rgb(214, 119, 34);
-  z-index: 1;
 }
 
 .telegram-message blockquote::after {
@@ -162,7 +160,6 @@
   flex: 0 0 auto;
   width: .1875rem;
   background: rgb(214, 119, 34);
-  z-index: 1;
 }
 
 .telegram-message pre code.hljs {

--- a/frontend/src/routes/components/renderer/css/telegram-renderer.css
+++ b/frontend/src/routes/components/renderer/css/telegram-renderer.css
@@ -56,7 +56,6 @@
 }
 .rendered-telegram .page_header {
     position: fixed;
-    z-index: 10;
     background-color: #ffffff;
     width: 100%;
     border-bottom: 1px solid #e3e6e8;
@@ -350,7 +349,6 @@ div.selected {
     background: rgba(0, 0, 0, .4);
     padding: 0px 5px;
     position: absolute;
-    z-index: 2;
     border-radius: 2px;
     right: 3px;
     bottom: 3px;
@@ -363,7 +361,6 @@ div.selected {
     height: 40px;
     line-height: 0;
     position: absolute;
-    z-index: 2;
     border-radius: 50%;
     overflow: hidden;
     margin: -20px auto 0 -20px;
@@ -378,7 +375,6 @@ div.selected {
     left: 50%;
     margin-left: -5px;
     margin-top: -9px;
-    z-index: 1;
     width: 0;
     height: 0;
     border-style: solid;


### PR DESCRIPTION
fixes #7 

* Close modal on background click
* remove all z-index stuff and move charCount to the right place to prevent it missing around with modal position